### PR TITLE
Remove default value of `authors`

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,9 @@ jobs:
       - uses: int128/hide-comment-action@v1
 ```
 
-It hides all comments created by `github-actions`.
+It hides all comments created by `github-actions` user.
+
+### Filter comments
 
 You can set the following conditions:
 
@@ -28,7 +30,9 @@ You can set the following conditions:
 - The body of comment ends with one of `ends-with`
 - The body of comment contains one of `contains`
 
-If a comment matches to **any** condition (i.e. evaluated as OR), this action hides it.
+This action hides comment(s) which matches to **any** condition, i.e., evaluated as OR.
+
+If no condition is given, this action hides comment(s) created by the user of GitHub token.
 
 
 ### Example: using `ends-with` condition
@@ -66,7 +70,7 @@ It ignores other events.
 
 | Name | Default | Description
 |------|----------|-------------
-| `authors` | `github-actions` | Multi-line string of author condition
+| `authors` | - | Multi-line string of author condition
 | `starts-with` | - | Multi-line string of starts-with condition
 | `ends-with` | - | Multi-line string of ends-with condition
 | `contains` | - | Multi-line string of contains condition

--- a/action.yaml
+++ b/action.yaml
@@ -4,7 +4,6 @@ inputs:
   authors:
     description: multi-line string of author condition
     required: false
-    default: github-actions
   starts-with:
     description: multi-line string of starts-with condition
     required: false

--- a/src/run.ts
+++ b/src/run.ts
@@ -19,6 +19,12 @@ export const run = async (inputs: Inputs): Promise<void> => {
   }
   const octokit = github.getOctokit(inputs.token)
 
+  if (!inputs.authors && !inputs.contains && !inputs.startsWith && !inputs.endsWith) {
+    const { data: authenticatedUser } = await octokit.rest.users.getAuthenticated()
+    core.info(`no condition is given, hide comments created by user ${authenticatedUser.login}`)
+    inputs.authors = [authenticatedUser.login]
+  }
+
   core.info(`query comments in pull request ${github.context.payload.pull_request.html_url ?? '?'}`)
   const q = await queryComments(octokit, {
     owner: github.context.repo.owner,


### PR DESCRIPTION
## Problem to solve
This action hide all comments created by `github-actions` if `authors` is not set. It confuses us if we set `starts-with` or some condition.

## Breaking change
Change the default behavior as follows:

- Before
  - If no condition is set, it hides comments created by `github-actions`
  - If `authors` is set, it hides comments created by them
  - If other condition is set, it hides comments which matched to it **or** created by `github-actions`
- After
  - If no condition is set, it hides comments created by the token user (typically `github-actions`)
  - If `authors` is set, it hides comments created by them
  - If some condition is set, it hides comments which matched to it
